### PR TITLE
ECR build refactor

### DIFF
--- a/.github/workflows/deployment-handler.yml
+++ b/.github/workflows/deployment-handler.yml
@@ -3,6 +3,14 @@ name: Deployment handler
 on:
   workflow_call:
     inputs:
+      build-step-name:
+        required: false
+        type: string
+        default: build
+      build-step-wait-timeout:
+        required: false
+        type: string
+        default: 1800 # 30 minutes
       cdk-config-path:
         required: false
         type: string
@@ -17,9 +25,6 @@ on:
         type: string
       deployment-target-name:
         required: true
-        type: string
-      dockerfile-path:
-        required: false
         type: string
       eks-role-arn:
         required: false
@@ -117,10 +122,10 @@ jobs:
       id: wait-for-build
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        checkName: build
+        checkName: ${{ inputs.build-step-name }}
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
         intervalSeconds: 30
-        timeoutSeconds: 1800 # 30 minutes
+        timeoutSeconds: ${{ inputs.build-step-wait-timeout }}
     - uses: riskalyze/deployment-actions/eks-helm-deploy@v2
       if: steps.wait-for-build.outputs.conclusion == 'success'
       with:

--- a/.github/workflows/deployment-handler.yml
+++ b/.github/workflows/deployment-handler.yml
@@ -107,20 +107,22 @@ jobs:
     needs:
     - helm-package
     permissions:
+      checks: read
       contents: read
       id-token: write
-      statuses: read
     runs-on: ubuntu-latest
     steps:
-    - uses: autotelic/action-wait-for-status-check@v1
+    - name: Wait for build to succeed
+      uses: fountainhead/action-wait-for-check@v1.0.0
       id: wait-for-build
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        statusName: build
+        checkName: build
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
         intervalSeconds: 30
         timeoutSeconds: 1800 # 30 minutes
     - uses: riskalyze/deployment-actions/eks-helm-deploy@v2
-      if: steps.wait-for-build.outputs.state == 'success'
+      if: steps.wait-for-build.outputs.conclusion == 'success'
       with:
         cluster: ${{ inputs.cluster }}
         environment: ${{ inputs.deployment-target-name }}
@@ -133,7 +135,7 @@ jobs:
         task: ${{ inputs.task }}
         twingate-service-key: ${{ secrets.twingate-service-key }}
     - name: Fail deploy if build failed
-      if: steps.wait-for-status.outputs.state != 'success'
+      if: steps.wait-for-build.outputs.conclusion != 'success'
       run: exit 1
 
   update-deployment:

--- a/.github/workflows/deployment-handler.yml
+++ b/.github/workflows/deployment-handler.yml
@@ -133,7 +133,7 @@ jobs:
         task: ${{ inputs.task }}
         twingate-service-key: ${{ secrets.twingate-service-key }}
     - name: Fail deploy if build failed
-      if: steps.wait-for-status.outputs.state !== 'success'
+      if: steps.wait-for-status.outputs.state != 'success'
       run: exit 1
 
   update-deployment:

--- a/.github/workflows/deployment-handler.yml
+++ b/.github/workflows/deployment-handler.yml
@@ -107,9 +107,9 @@ jobs:
     needs:
     - helm-package
     permissions:
-      checks: read
       contents: read
       id-token: write
+      statuses: read
     runs-on: ubuntu-latest
     steps:
     - uses: autotelic/action-wait-for-status-check@v1

--- a/.github/workflows/deployment-handler.yml
+++ b/.github/workflows/deployment-handler.yml
@@ -112,13 +112,15 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-    - uses: lewagon/wait-on-check-action@v1.0.0
+    - uses: autotelic/action-wait-for-status-check@v1
+      id: wait-for-build
       with:
-        ref: ${{ github.ref }}
-        check-name: build
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        wait-interval: 30
+        token: ${{ secrets.GITHUB_TOKEN }}
+        statusName: build
+        intervalSeconds: 30
+        timeoutSeconds: 1800 # 30 minutes
     - uses: riskalyze/deployment-actions/eks-helm-deploy@v2
+      if: steps.wait-for-build.outputs.state == 'success'
       with:
         cluster: ${{ inputs.cluster }}
         environment: ${{ inputs.deployment-target-name }}
@@ -130,6 +132,9 @@ jobs:
         role-arn: ${{ inputs.eks-role-arn }}
         task: ${{ inputs.task }}
         twingate-service-key: ${{ secrets.twingate-service-key }}
+    - name: Fail deploy if build failed
+      if: steps.wait-for-status.outputs.state !== 'success'
+      run: exit 1
 
   update-deployment:
     needs:

--- a/.github/workflows/deployment-handler.yml
+++ b/.github/workflows/deployment-handler.yml
@@ -9,24 +9,6 @@ on:
       cdk-role-arn:
         required: false
         type: string
-      codeartifact-domain: # TODO: (Breaking change) Remove all codeartifact inputs except codeartifact-domain-owner and codeartifact-role-arn and just use defaults instead
-        required: false
-        type: string
-      codeartifact-domain-owner:
-        required: false
-        type: string
-      codeartifact-namespace:
-        required: false
-        type: string
-      codeartifact-region:
-        required: false
-        type: string
-      codeartifact-repository:
-        required: false
-        type: string
-      codeartifact-role-arn:
-        required: false
-        type: string
       cluster:
         required: false
         type: string
@@ -37,15 +19,6 @@ on:
         required: true
         type: string
       dockerfile-path:
-        required: false
-        type: string
-      ecr-account-id:
-        required: false
-        type: string
-      ecr-region:
-        required: false
-        type: string
-      ecr-role-arn:
         required: false
         type: string
       eks-role-arn:
@@ -69,6 +42,15 @@ on:
       region:
         required: true
         type: string
+      shared-account-id:
+        required: false
+        type: string
+      shared-region:
+        required: false
+        type: string
+      shared-role-arn:
+        required: false
+        type: string
       stacks:
         required: false
         type: string
@@ -76,10 +58,6 @@ on:
         required: true
         type: string
     secrets:
-      ecr-lifecycle-policy:
-        required: false
-      ecr-repo-policy:
-        required: false
       twingate-service-key:
         required: false
 
@@ -95,32 +73,14 @@ jobs:
     - uses: riskalyze/deployment-actions/cdk-deploy@v2
       id: cdk-deploy
       with:
-        codeartifact-domain-owner: ${{ inputs.codeartifact-domain-owner }}
-        codeartifact-role-arn: ${{ inputs.codeartifact-role-arn || inputs.ecr-role-arn }} # TODO: Remove this fallback when all workflows are updated to pass in codeartifact-role-arn
+        codeartifact-domain-owner: ${{ inputs.shared-account-id }}
+        codeartifact-role-arn: ${{ inputs.shared-role-arn }}
         env-vars: ACCOUNT_NAME=${{ inputs.deployment-target-name }},NAMESPACE=${{ inputs.namespace }}
         environment: ${{ inputs.environment }}
         cdk-region: ${{ inputs.region }}
         cdk-role-arn: ${{ inputs.cdk-role-arn }}
         path: ${{ inputs.cdk-config-path }}
         task: ${{ inputs.task }}
-
-  ecr-build-push:
-    if: inputs.dockerfile-path != '' && inputs.task == 'deploy'
-    concurrency: ${{ github.sha }}
-    permissions:
-      contents: read
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: riskalyze/build-actions/ecr-build-push@v1
-        with:
-          codeartifact-domain-owner: ${{ inputs.codeartifact-domain-owner }}
-          codeartifact-role-arn: ${{ inputs.codeartifact-role-arn || inputs.ecr-role-arn }}
-          ecr-region: ${{ inputs.ecr-region }}
-          ecr-lifecycle-policy: ${{ secrets.ecr-lifecycle-policy }}
-          ecr-repo-policy: ${{ secrets.ecr-repo-policy }}
-          ecr-role-arn: ${{ inputs.ecr-role-arn }}
-          path: ${{ inputs.dockerfile-path }}
 
   helm-package:
     if: inputs.helm-chart-path != '' && inputs.task == 'deploy'
@@ -131,9 +91,9 @@ jobs:
     steps:
     - uses: riskalyze/deployment-actions/helm-package@v2
       with:
-        ecr-account-id: ${{ inputs.ecr-account-id }}
-        ecr-region: ${{ inputs.ecr-region }}
-        ecr-role-arn: ${{ inputs.ecr-role-arn }}
+        ecr-account-id: ${{ inputs.shared-account-id }}
+        ecr-region: ${{ inputs.shared-region || 'us-east-2' }}
+        ecr-role-arn: ${{ inputs.shared-role-arn }}
         path: ${{ inputs.helm-chart-path }}
 
   eks-helm-deploy:
@@ -142,17 +102,22 @@ jobs:
     if: |
       always() &&
       inputs.helm-chart-path != '' &&
-      (needs.ecr-build-push.result == 'success' || needs.ecr-build-push.result == 'skipped') &&
       (needs.helm-package.result == 'success' || needs.helm-package.result == 'skipped')
     concurrency: eks-helm-${{ inputs.environment }}
     needs:
-    - ecr-build-push
     - helm-package
     permissions:
+      checks: read
       contents: read
       id-token: write
     runs-on: ubuntu-latest
     steps:
+    - uses: lewagon/wait-on-check-action@v1.0.0
+      with:
+        ref: ${{ github.ref }}
+        check-name: build
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 30
     - uses: riskalyze/deployment-actions/eks-helm-deploy@v2
       with:
         cluster: ${{ inputs.cluster }}


### PR DESCRIPTION
Refactors the `ecr-build-push` out of `deployment-handler`, expecting the service repo to include a build workflow that will invoke `ecr-build-push`. This lets us decouple the docker image build from deployments, which is more logical and improves a few scenarios:

- No redundant builds - if a service is deployed on master to _N_ environments, then each push to master would create _N_ deployments and build the Docker image _N_ times. With this change, it is only built once for each push to master, then reused across all the deployments.
- Prod rollbacks - won't need to wait for a docker build step to finish, it will use the existing built image.
- Initial deploys - in many cases, the user has already pushed the branch and will have a built image waiting to be deployed, so the first time creating a preview environment will be much quicker.
- Docker image reuse - the build pipeline can reuse the built docker image for other steps, such as tests or vulnerability scans.
- More predictable behavior - most users expect the docker image to be built on push (this is the current behavior), so we will have less retraining to do.

To make this work, the `deployment-handler` just waits until a status check named `build` passes. If it doesn't see that check passing within 30 minutes, it times out and the deployment fails. If this is not long enough, there is an input for `build-step-wait-timeout` to override. There is also an input for `build-step-name` to override if the build workflow is called something besides `build`.